### PR TITLE
Fixed Graph Drawing Bug

### DIFF
--- a/server/resources/js/app/device_metric_graphs.js
+++ b/server/resources/js/app/device_metric_graphs.js
@@ -13,6 +13,9 @@ class MetricGrapher {
     // 30 seconds times sample rate gives number of metrics recorded.
     let recordedTime = 30 * (1 / timeInterval);
 
+    /** @private @const Number */
+    this.BYTE_CONVERSION = 1024.0;
+
     /** @private @const {Array<number>} */
     this.cpuUsageHistory_ = [];
     /** @private @const {Array<number>} */
@@ -110,13 +113,18 @@ class MetricGrapher {
     this.cpuUsageHistory_.push(this.metrics.cpuUsage * 100);
     this.cpuUsageHistory_.shift();
 
-    this.memoryUsageHistory_.push(this.metrics.memUsage / 1024.0);
+    // Divided by 1024 to convert from KB to MB.
+    this.memoryUsageHistory_.push(this.metrics.memUsage /
+      this.BYTE_CONVERSION);
     this.memoryUsageHistory_.shift();
 
-    this.networkSentHistory_.push(this.metrics.netSentPerSec / 1024.0);
+    // Divided by 1024 to convert from Bytes to KB.
+    this.networkSentHistory_.push(this.metrics.netSentPerSec /
+      this.BYTE_CONVERSION);
     this.networkSentHistory_.shift();
 
-    this.networkReceiveHistory_.push(this.metrics.netReceivePerSec / 1024.0);
+    this.networkReceiveHistory_.push(this.metrics.netReceivePerSec /
+      this.BYTE_CONVERSION);
     this.networkReceiveHistory_.shift();
 
     this.cpuGraph.data.datasets[0].data = this.cpuUsageHistory_;

--- a/server/resources/js/app/device_metric_graphs.js
+++ b/server/resources/js/app/device_metric_graphs.js
@@ -113,10 +113,10 @@ class MetricGrapher {
     this.memoryUsageHistory_.push(this.metrics.memUsage / 1024.0);
     this.memoryUsageHistory_.shift();
 
-    this.networkSentHistory_.push(this.metrics.netSentPerSec);
+    this.networkSentHistory_.push(this.metrics.netSentPerSec / 1024.0);
     this.networkSentHistory_.shift();
 
-    this.networkReceiveHistory_.push(this.metrics.netReceivePerSec);
+    this.networkReceiveHistory_.push(this.metrics.netReceivePerSec / 1024.0);
     this.networkReceiveHistory_.shift();
 
     this.cpuGraph.data.datasets[0].data = this.cpuUsageHistory_;
@@ -162,6 +162,9 @@ class MetricGrapher {
       hover: {
         mode: null
       },
+      animation: {
+            duration: 0,
+        },
     }
   }
 

--- a/server/template/current.xhtml
+++ b/server/template/current.xhtml
@@ -23,20 +23,20 @@
 
     <div class="col-md-4">
       <div class="metrics-graph">
-        <h4>CPU Usage</h4>
+        <h4>CPU Usage (%)</h4>
         <canvas id="cpu-usage-graph">
         </canvas>
       </div>
 
       <div class="metrics-graph">
-        <h4>Memory Usage</h4>
+        <h4>Memory Usage (MB)</h4>
         <canvas id="mem-usage-graph"></canvas>
       </div>
 
       <div class="metrics-graph">
         <div class="row">
           <div class="col-md-8">
-            <h4>Network Usage</h4>
+            <h4>Network Usage (KB/s)</h4>
           </div>
           <div class="col-md-4">
             <span id="send">Sent</span><span id="receive">Received</span>


### PR DESCRIPTION
Fixed bug where the graph lines were moving around after being drawn.  It was fixed by disabling graph animation.  It worked with animation before so the bug is not 100% resolved, but this will work for now.