### PR TITLE
Fixed bug where historical logs were not showing up, causing a 500 error

### DIFF
--- a/server/datastore_interfaces/mongo_datastore_interface.py
+++ b/server/datastore_interfaces/mongo_datastore_interface.py
@@ -73,7 +73,7 @@ class MongoDatastoreInterface(base_datastore_interface.DatastoreInterface):
                                     'app_name':
                                         self.get_raw_app_name_from_alias(
                                             api_key, device_name, app_name),
-                                    'start_time': start_time})[0]['logEntries']
+                                    'start_time': start_time})
 
     def retrieve_devices(self, api_key):
         """This function retrieves a list of devices associated with the given API Key.

--- a/server/tests/mongo_datastore_interface_tests.py
+++ b/server/tests/mongo_datastore_interface_tests.py
@@ -102,7 +102,7 @@ def test_retrieve_logs():
                   log_entries)
     di.add_device_app(api_key, device_name, app_name)
     log = di.retrieve_logs(api_key, device_name, app_name, start_time)
-    assert log == logs
+    assert log[0]['logEntries'] == logs
     di.clear_datastore()
 
 


### PR DESCRIPTION
Fixed by updating the dictionary to work with the parsing library changes.